### PR TITLE
fix: add displayName to aid debugging

### DIFF
--- a/src/groqLogo.tsx
+++ b/src/groqLogo.tsx
@@ -39,3 +39,4 @@ export const GroqLogo = forwardRef(function GroqLogo(
     </svg>
   )
 })
+GroqLogo.displayName = 'ForwardRef(GroqLogo)'

--- a/src/groqMonogram.tsx
+++ b/src/groqMonogram.tsx
@@ -27,3 +27,4 @@ export const GroqMonogram = forwardRef(function GroqMonogram(
     </svg>
   )
 })
+GroqMonogram.displayName = 'ForwardRef(GroqMonogram)'

--- a/src/sanityLogo.tsx
+++ b/src/sanityLogo.tsx
@@ -79,3 +79,4 @@ export const SanityLogo = forwardRef(function SanityLogo(
     </svg>
   )
 })
+SanityLogo.displayName = 'ForwardRef(SanityLogo)'

--- a/src/sanityMonogram.tsx
+++ b/src/sanityMonogram.tsx
@@ -59,3 +59,4 @@ export const SanityMonogram = forwardRef(function SanityMonogram(
     </svg>
   )
 })
+SanityMonogram.displayName = 'ForwardRef(SanityMonogram)'


### PR DESCRIPTION
For the same reasons as explained in https://github.com/sanity-io/icons/pull/92